### PR TITLE
Added ability to clone specific customization branch

### DIFF
--- a/bin/install_customizations
+++ b/bin/install_customizations
@@ -11,7 +11,14 @@ if ! [[ -z ${CUSTOMIZATION_GIT_REPO} ]];
     echo "Cloning custom repo...";
     # remove custom to allow for cloning to that directory name
     rm -rf ./custom;
-    git clone $CUSTOMIZATION_GIT_REPO custom;
+    # clone specific branch if env set
+    if ! [[ -z ${CUSTOMIZATION_GIT_REPO_BRANCH} ]];
+      then
+        echo "Cloning custom repo and branch...";
+        git clone -b $CUSTOMIZATION_GIT_REPO_BRANCH $CUSTOMIZATION_GIT_REPO custom;
+      else
+        git clone $CUSTOMIZATION_GIT_REPO custom;
+    fi;
     echo "Installing custom packages...";
     cd ./custom;
     npm i;


### PR DESCRIPTION
### Description of Change
<!-- Thanks for contributing! Please describe your addition and review the requirements below. Review the contributor's guide before submitting your pull request: https://github.com/nytimes/library/blob/master/CONTRIBUTING.md -->
Just a minor tweak in the script to check if the following environment variable is set `CUSTOMIZATION_GIT_REPO_BRANCH` and clone that branch. This should help us when testing changes on the QA app from being deployed to production unintentionally.



